### PR TITLE
RFC add a trait for helping with expectations.

### DIFF
--- a/Lib/CounterHelperTrait.php
+++ b/Lib/CounterHelperTrait.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Andy Dawson, 2013
+ */
+trait CounterHelperTrait {
+
+/**
+ * List of counters used by this test case
+ *
+ * @var array
+ */
+	protected $_expectationCounters = array();
+
+/**
+ * Returns a matcher that matches when the method it is evaluated for
+ * is invoked _next_
+ *
+ * Permits using multiple named counters
+ *
+ * @param mixed $name string or object
+ * @return PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex
+ */
+	public function next($name = '') {
+		if (is_object($name)) {
+			$name = get_class($name);
+		}
+		if (!isset($this->_expectationCounters[$name])) {
+			$this->_expectationCounters[$name] = 0;
+		} else {
+			$this->_expectationCounters[$name] += 1;
+		}
+		return $this->at($this->_expectationCounters[$name]);
+	}
+}

--- a/Test/Lib/CounterHelperTraitTest.php
+++ b/Test/Lib/CounterHelperTraitTest.php
@@ -1,0 +1,83 @@
+<?php
+require_once dirname(dirname(dirname(__FILE__))) . '/Lib/CounterHelperTrait.php';
+
+class CounterHelperTest extends PHPUnit_Framework_TestCase {
+
+	use CounterHelperTrait;
+
+	public function testNext() {
+		$next = $this->next();
+		$this->assertInstanceOf('PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex', $next);
+	}
+
+	public function testCounters() {
+		$this->Test = $this->getMock('CounterHelperTest', array('at'));
+		$this->Test
+			->staticExpects($this->any())
+			->method('at')
+			->will($this->returnCallback(function($input) {
+				return $input;
+			}));
+
+		$this->assertSame(0, $this->Test->next());
+		$this->assertSame(1, $this->Test->next());
+		$this->assertSame(2, $this->Test->next());
+		$this->assertSame(3, $this->Test->next());
+		$this->assertSame(4, $this->Test->next());
+		$this->assertSame(5, $this->Test->next());
+	}
+
+	public function testCountersNamed() {
+		$this->Test = $this->getMock('CounterHelperTest', array('at'));
+		$this->Test
+			->staticExpects($this->any())
+			->method('at')
+			->will($this->returnCallback(function($input) {
+				return $input;
+			}));
+
+		$this->assertSame(0, $this->Test->next());
+		$this->assertSame(0, $this->Test->next('Foo'));
+		$this->assertSame(0, $this->Test->next('Bar'));
+		$this->assertSame(1, $this->Test->next('Foo'));
+		$this->assertSame(1, $this->Test->next());
+		$this->assertSame(2, $this->Test->next());
+		$this->assertSame(3, $this->Test->next());
+	}
+
+	public function testCountersObjectNamed() {
+		$this->Test = $this->getMock('CounterHelperTest', array('at'));
+		$this->Test
+			->staticExpects($this->any())
+			->method('at')
+			->will($this->returnCallback(function($input) {
+				return $input;
+			}));
+
+		$this->assertSame(0, $this->Test->next());
+		$this->assertSame(0, $this->Test->next($this->Test));
+		$this->assertSame(0, $this->Test->next($this));
+		$this->assertSame(1, $this->Test->next($this->Test));
+		$this->assertSame(1, $this->Test->next());
+		$this->assertSame(2, $this->Test->next());
+		$this->assertSame(3, $this->Test->next());
+	}
+
+	public function testCountersDontPersist() {
+		$next = $this->next();
+		$this->assertSame('invoked at sequence index 0', $next->toString());
+	}
+
+/**
+ * testCountersDontPersist2
+ *
+ * Verify that by default the internal state of the counters, does not persist
+ * between tests
+ *
+ * @return void
+ */
+	public function testCountersDontPersist2() {
+		$next = $this->next();
+		$this->assertSame('invoked at sequence index 0', $next->toString());
+	}
+}


### PR DESCRIPTION
Permit this:

```
$Foo
    ->expects($this->next())
    ->method(...
$Foo
    ->expects($this->next())
    ->method(...
$Bar
    ->expects($this->next('Bar'))
    ->method(...
$Bar
    ->expects($this->next('Bar'))
    ->method(...
$Foo
    ->expects($this->next())
    ->method(...
```
